### PR TITLE
added initparameter for scalatra to enable production mode to prevent…

### DIFF
--- a/src/main/scala/ScalatraBootstrap.scala
+++ b/src/main/scala/ScalatraBootstrap.scala
@@ -40,6 +40,9 @@ class ScalatraBootstrap extends LifeCycle {
     context.mount(new PullRequestsController, "/*")
     context.mount(new RepositorySettingsController, "/*")
 
+    // Set this parameter when run gitbucket on production mode
+    context.initParameters("org.scalatra.environment") = "production"
+
     // Create GITBUCKET_HOME directory if it does not exist
     val dir = new java.io.File(Directory.GitBucketHome)
     if(!dir.exists){

--- a/src/main/scala/gitbucket/core/controller/ControllerBase.scala
+++ b/src/main/scala/gitbucket/core/controller/ControllerBase.scala
@@ -1,6 +1,5 @@
 package gitbucket.core.controller
 
-import java.io.{PrintStream, PrintWriter}
 
 import gitbucket.core.api.ApiError
 import gitbucket.core.model.Account
@@ -18,7 +17,7 @@ import org.scalatra.json._
 import javax.servlet.http.{HttpServletRequest, HttpServletResponse}
 import javax.servlet.{FilterChain, ServletRequest, ServletResponse}
 
-import scala.util.{Failure, Success, Try}
+import scala.util.Try
 
 
 /**
@@ -65,23 +64,7 @@ abstract class ControllerBase extends ScalatraFilter
         httpRequest.setAttribute(Keys.Request.APIv3, true)
       }
       // Scalatra actions
-      Try(super.doFilter(request, response, chain)) match {
-        case Success(s) =>
-        case Failure(ex) => {
-          response.asInstanceOf[HttpServletResponse].setStatus(400)
-          response.setContentType("text/plain")
-          val ps = new PrintStream(response.getOutputStream)
-          val pw = new PrintWriter(ps)
-          pw.print(
-            s"""{
-                |"message" : "400 Bad Request"
-                |}
-             """.stripMargin)
-          pw.close
-          ps.close
-          response.getOutputStream.close
-        }
-      }
+      super.doFilter(request, response, chain)
     }
   } finally {
     contextCache.remove();


### PR DESCRIPTION
by adding this in scalatra bootstrap

context.initParameters("org.scalatra.environment") = "production"

it forces scalatra to run in production mode. This will prevent revealing debug info