### PR TITLE
CS Fixes - uses hex encoding/decoding for the filepath

### DIFF
--- a/src/main/scala/gitbucket/core/controller/ApiController.scala
+++ b/src/main/scala/gitbucket/core/controller/ApiController.scala
@@ -410,7 +410,7 @@ trait ApiControllerBase extends ControllerBase {
       } yield {
         
         using(Git.open(getRepositoryDir(repository.owner, repository.name))){ git =>
-          getFileContent(git, branch, filename.replace("|","/"))
+          getFileContent(git, branch, filename.sliding(2, 2).toArray.map(Integer.parseInt(_, 16).toChar).mkString)
         } 
         
       }) getOrElse


### PR DESCRIPTION
### Before submitting a pull-request to Gitbucket I have first:

- [] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [] rebased my branch over master
- [] verified that project is compiling
- [] verified that tests are passing
- [] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [] [marked as closed](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

