### PR TITLE
Add repo info as part of the return body for GET user API

### DIFF
--- a/src/main/scala/gitbucket/core/controller/AccountController.scala
+++ b/src/main/scala/gitbucket/core/controller/AccountController.scala
@@ -436,7 +436,7 @@ trait AccountControllerBase extends AccountManagementControllerBase {
     val userName = params("userName")
     getAccountByUserName(userName, true) match {
       case Some(account) => {
-
+        val repos = getVisibleRepositories(Some(account), Some(userName))
 
         val body = org.json4s.jackson.Serialization.write(
           Map("userName" -> account.userName,
@@ -448,7 +448,8 @@ trait AccountControllerBase extends AccountManagementControllerBase {
             "lastLoginDate" -> account.lastLoginDate,
             "image" -> account.image.getOrElse(""),
             "isGroupAccount" -> account.isGroupAccount,
-            "isRemoved" -> account.isRemoved
+            "isRemoved" -> account.isRemoved,
+            "repositories" -> repos
           )
         )
 


### PR DESCRIPTION
### Before submitting a pull-request to Gitbucket I have first:

- [] read the [contribution guidelines](https://github.com/gitbucket/gitbucket/blob/master/.github/CONTRIBUTING.md)
- [] rebased my branch over master
- [] verified that project is compiling
- [] verified that tests are passing
- [] squashed my commits as appropriate *(keep several commits if it is relevant to understand the PR)*
- [] [marked as closed](https://help.github.com/articles/closing-issues-via-commit-messages/) all issue ID that this PR should correct

